### PR TITLE
Configure to support absolute Imports 

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import HomePage from '../features/HomePage';
+import HomePage from 'features/HomePage';
 
 export default function MainPage() {
   return <HomePage />;

--- a/src/pages/other-page/index.tsx
+++ b/src/pages/other-page/index.tsx
@@ -1,4 +1,4 @@
-import OtherPage from '../../features/OtherPage';
+import OtherPage from 'features/OtherPage';
 
 export default function MainPage() {
   return <OtherPage />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
Next.js has in-built support for the `baseUrl` option of tsconfig.json file.

These option allow you to alias project directories to absolute paths, making it easier to import modules and avoid the [import path hell](https://medium.com/thefork/escaping-relative-import-paths-hell-in-javascript-9f258baeb15e).
 For example:

```js
// before
import HomePage from '../features/HomePage';
// after
import HomePage from 'features/HomePage';
```